### PR TITLE
Config System Refactor

### DIFF
--- a/Sovereign
+++ b/Sovereign
@@ -20,6 +20,9 @@ $container->delegate(
     new League\Container\ReflectionContainer
 );
 
+// register default config file
+$container->add('configFile', BASEDIR . '/config/config.php');
+
 // Add the default system service provider
 $container->addServiceProvider(\Sovereign\Service\SystemServiceProvider::class);
 
@@ -30,6 +33,8 @@ try {
     // Init the bot
     $container->get('log')->addInfo('Sovereign is starting up..');
     $bot = $container->get('app');
+
+    // Register the default plugins and services, and boot them.
     $container->addServiceProvider(\Sovereign\Service\SystemPluginServiceProvider::class);
 } catch (\Exception $e) {
     $container->get('log')->addError('An error occurred: ' . $e->getMessage());

--- a/composer.json
+++ b/composer.json
@@ -21,5 +21,6 @@
     "monolog/monolog": "1.19.*",
     "norkunas/youtube-dl-php": "0.2.*",
     "league/container": "^2.2"
-  }
+  },
+  "bin": ["Sovereign"]
 }

--- a/src/Service/SystemServiceProvider.php
+++ b/src/Service/SystemServiceProvider.php
@@ -38,7 +38,7 @@ class SystemServiceProvider extends AbstractServiceProvider
         $container->get('log')->pushHandler(new \Monolog\Handler\StreamHandler('php://stdout', \Monolog\Logger::INFO));
 
         $container->share('db', 'Sovereign\Lib\Db')->withArgument('config')->withArgument('log');
-        $container->share('config', 'Sovereign\Lib\Config');
+        $container->share('config', 'Sovereign\Lib\Config')->withArgument('configFile')->withArgument('log');
         $container->share('curl', 'Sovereign\Lib\cURL')->withArgument('log');
         $container->share('settings', 'Sovereign\Lib\Settings')->withArgument('db');
         $container->share('permissions', 'Sovereign\Lib\Permissions')->withArgument('db')->withArgument('config');


### PR DESCRIPTION
Remove hardcoded dependency on the config file from the config library.
Move the config file location into the service container.
Add the ability to load a config file into the config service on demand.
Store resolved config array in memory until reloaded.

Log on failed loading of config file and failed access of config vars.
